### PR TITLE
フィボナッチ数列のスキップ処理の高速化

### DIFF
--- a/Fibonacci.cs
+++ b/Fibonacci.cs
@@ -1,21 +1,31 @@
 void Main()
 {
-	GetFibo().Take(10).Dump();
+	GetFibo(skip:100000000).Take(10).Dump();
 }
 
 // Define other methods and classes here
 
-public IEnumerable<int> GetFibo() 
+const int F0 = 0;
+const int F1 = 1;
+
+public IEnumerable<int> GetFibo(int skip=0) 
 {
-	yield return 0;
-	yield return 1;
-	int i1 = 0;
-	int i2 = 1;
-	while (true) 
+	int i1 = F0;
+	int i2 = F1;
+	for (int i = 0; i < skip; i++)
 	{
 		int fibo = i1 + i2;
  		i1 = i2;
 		i2 = fibo;
+	}
+	
+	yield return i1;
+	yield return i2;
+	while (true) 
+	{
+		int fibo = i1 + i2;
 		yield return fibo;	
+ 		i1 = i2;
+		i2 = fibo;
 	}
 }


### PR DESCRIPTION
Skip 処理時は yield return を呼ばないようにする事で、実行速度 2倍ぐらいになってる……はず
